### PR TITLE
Fix elision logic in readNote

### DIFF
--- a/Safe.hs
+++ b/Safe.hs
@@ -236,8 +236,9 @@ readNote msg s = case [x | (x,t) <- reads s, ("","") <- lex t] of
                      []  -> error $ "Prelude.read: no parse, " ++ msg ++ ", on " ++ prefix
                      _   -> error $ "Prelude.read: ambiguous parse, " ++ msg ++ ", on " ++ prefix
     where
-        prefix = '\"' : a ++ if null b then "\"" else "..."
-            where (a,b) = splitAt 10 s
+        maxLength = 10
+        prefix = '\"' : a ++ if length s <= maxLength then (b ++ "\"") else "...\""
+            where (a,b) = splitAt (maxLength - 3) s
 
 
 -- |


### PR DESCRIPTION
If a string was long enough for elision, but only by 2 characters, the
elision was longer than the rest of the string. Instead, factor in the
elision into the cutoff calculation.

Also add a trailing double quote after the ellipses.

Addresses #1.
