### PR TITLE
Add zip3 functions

### DIFF
--- a/Safe/Exact.hs
+++ b/Safe/Exact.hs
@@ -65,6 +65,17 @@ zipWithExact_ err nil cons = f
         f _ [] = err "first list is longer than the second"
 
 
+{-# INLINE zipWith3Exact_ #-}
+zipWith3Exact_ :: (String -> r) -> r -> (a -> b -> c -> r -> r) -> [a] -> [b] -> [c] -> r
+zipWith3Exact_ err nil cons = f
+    where
+        f (x:xs) (y:ys) (z:zs) = cons x y z $ f xs ys zs
+        f [] [] [] = nil
+        f [] _ _ = err "first list is shorter than the others"
+        f _ [] _ = err "second list is shorter than the others"
+        f _ _ [] = err "third list is shorter than the others"
+
+
 ---------------------------------------------------------------------
 -- TAKE/DROP/SPLIT
 
@@ -161,30 +172,30 @@ zipWithExactDef def = fromMaybe def .^^ zipWithExactMay
 -- >   | length xs == length ys && length xs == length zs = zip3 xs ys zs
 -- >   | otherwise                                        = error "some message"
 zip3Exact :: [a] -> [b] -> [c] -> [(a,b,c)]
-zip3Exact = undefined
+zip3Exact = zipWith3Exact_ (addNote "" "zip3Exact") [] (\a b c xs -> (a, b, c) : xs)
 
 -- |
 -- > zipWith3Exact f xs ys zs =
 -- >   | length xs == length ys && length xs == length zs = zipWith3 f xs ys zs
 -- >   | otherwise                                        = error "some message"
 zipWith3Exact :: (a -> b -> c -> d) -> [a] -> [b] -> [c] -> [d]
-zipWith3Exact f = undefined
+zipWith3Exact f = zipWith3Exact_ (addNote "" "zipWith3Exact") [] (\a b c xs -> f a b c : xs)
 
 
 zip3ExactNote :: String -> [a] -> [b] -> [c]-> [(a,b,c)]
-zip3ExactNote note = undefined
+zip3ExactNote note = zipWith3Exact_ (addNote note "zip3ExectNote") [] (\a b c xs -> (a,b,c) : xs)
 
 zip3ExactMay :: [a] -> [b] -> [c] -> Maybe [(a,b,c)]
-zip3ExactMay = undefined
+zip3ExactMay = zipWith3Exact_ (const Nothing) (Just [])  (\a b c xs -> fmap ((a,b,c) :) xs)
 
 zip3ExactDef :: [(a,b,c)] -> [a] -> [b] -> [c] -> [(a,b,c)]
-zip3ExactDef def = undefined
+zip3ExactDef def = fromMaybe def .^^ zip3ExactMay
 
 zipWith3ExactNote :: String -> (a -> b -> c -> d) -> [a] -> [b] -> [c] -> [d]
-zipWith3ExactNote note f = undefined
+zipWith3ExactNote note f = zipWith3Exact_ (addNote note "zipWith3ExactNote") []  (\a b c xs -> f a b c : xs)
 
 zipWith3ExactMay :: (a -> b -> c -> d) -> [a] -> [b] -> [c] -> Maybe [d]
-zipWith3ExactMay f = undefined
+zipWith3ExactMay f = zipWith3Exact_ (const Nothing) (Just [])  (\a b c xs -> fmap (f a b c :) xs)
 
 zipWith3ExactDef :: [d] -> (a -> b -> c -> d) -> [a] -> [b] -> [c] -> [d]
-zipWith3ExactDef def = undefined
+zipWith3ExactDef def = fromMaybe def .^^^ zipWith3ExactMay

--- a/Safe/Exact.hs
+++ b/Safe/Exact.hs
@@ -19,12 +19,15 @@ module Safe.Exact(
     -- * New functions
     takeExact, dropExact, splitAtExact,
     zipExact, zipWithExact,
+    zip3Exact, zipWith3Exact,
     -- * Safe wrappers
     takeExactMay, takeExactNote, takeExactDef,
     dropExactMay, dropExactNote, dropExactDef,
     splitAtExactMay, splitAtExactNote, splitAtExactDef,
     zipExactMay, zipExactNote, zipExactDef,
     zipWithExactMay, zipWithExactNote, zipWithExactDef,
+    zip3ExactMay, zip3ExactNote, zip3ExactDef,
+    zipWith3ExactMay, zipWith3ExactNote, zipWith3ExactDef,
     ) where
 
 import Control.Arrow
@@ -151,3 +154,37 @@ zipWithExactMay f = zipWithExact_ (const Nothing) (Just [])  (\a b xs -> fmap (f
 
 zipWithExactDef :: [c] -> (a -> b -> c) -> [a] -> [b] -> [c]
 zipWithExactDef def = fromMaybe def .^^ zipWithExactMay
+
+
+-- |
+-- > zip3Exact xs ys zs =
+-- >   | length xs == length ys && length xs == length zs = zip3 xs ys zs
+-- >   | otherwise                                        = error "some message"
+zip3Exact :: [a] -> [b] -> [c] -> [(a,b,c)]
+zip3Exact = undefined
+
+-- |
+-- > zipWith3Exact f xs ys zs =
+-- >   | length xs == length ys && length xs == length zs = zipWith3 f xs ys zs
+-- >   | otherwise                                        = error "some message"
+zipWith3Exact :: (a -> b -> c -> d) -> [a] -> [b] -> [c] -> [d]
+zipWith3Exact f = undefined
+
+
+zip3ExactNote :: String -> [a] -> [b] -> [c]-> [(a,b,c)]
+zip3ExactNote note = undefined
+
+zip3ExactMay :: [a] -> [b] -> [c] -> Maybe [(a,b,c)]
+zip3ExactMay = undefined
+
+zip3ExactDef :: [(a,b,c)] -> [a] -> [b] -> [c] -> [(a,b,c)]
+zip3ExactDef def = undefined
+
+zipWith3ExactNote :: String -> (a -> b -> c -> d) -> [a] -> [b] -> [c] -> [d]
+zipWith3ExactNote note f = undefined
+
+zipWith3ExactMay :: (a -> b -> c -> d) -> [a] -> [b] -> [c] -> Maybe [d]
+zipWith3ExactMay f = undefined
+
+zipWith3ExactDef :: [d] -> (a -> b -> c -> d) -> [a] -> [b] -> [c] -> [d]
+zipWith3ExactDef def = undefined

--- a/Safe/Util.hs
+++ b/Safe/Util.hs
@@ -11,6 +11,9 @@ import Data.Maybe
 (.^^) :: (b -> c) -> (a1 -> a2 -> a3 -> b) -> a1 -> a2 -> a3 -> c
 (.^^) f g x1 x2 x3 = f (g x1 x2 x3)
 
+(.^^^) :: (b -> c) -> (a1 -> a2 -> a3 -> a4 -> b) -> a1 -> a2 -> a3 -> a4 -> c
+(.^^^) f g x1 x2 x3 x4 = f (g x1 x2 x3 x4)
+
 liftMay :: (a -> Bool) -> (a -> b) -> (a -> Maybe b)
 liftMay test func val = if test val then Nothing else Just $ func val
 

--- a/Test.hs
+++ b/Test.hs
@@ -78,6 +78,28 @@ main = do
         f "zip" zipExact zipExactMay zipExactNote
         f "zipWith" (zipWithExact (,)) (zipWithExactMay (,)) (flip zipWithExactNote (,))
 
+    take 2 (zip3Exact [1,2,3] [1,2,3] [1,2]) === [(1,1,1),(2,2,2)]
+    zip3Exact [d1,2] [d1,2,3] [d1,2,3] `errs` ["Safe.Exact.zip3Exact","first list is shorter than the others"]
+    zip3Exact [d1,2,3] [d1,2] [d1,2,3] `errs` ["Safe.Exact.zip3Exact","second list is shorter than the others"]
+    zip3Exact [d1,2,3] [d1,2,3] [d1,2] `errs` ["Safe.Exact.zip3Exact","third list is shorter than the others"]
+    zip3Exact dNil dNil dNil === []
+
+    quickCheck $ \(List10 (xs :: [Int])) x1 x2 -> do
+        let ys = maybeToList x1 ++ xs
+        let zs = maybeToList x2 ++ xs
+        let res = zip3 xs ys zs
+        let f name exact may note =
+                if isNothing x1 && isNothing x2 then do
+                    exact xs ys zs === res
+                    note "foo" xs ys zs === res
+                    may xs ys zs === Just res
+                else do
+                    exact xs ys zs `err` ("Safe.Exact." ++ name ++ "Exact")
+                    note "foo" xs ys zs `errs` ["Safe.Exact." ++ name ++ "ExactNote","foo"]
+                    may xs ys zs === Nothing
+        f "zip3" zip3Exact zip3ExactMay zip3ExactNote
+        f "zipWith3" (zipWith3Exact (,,)) (zipWith3ExactMay (,,)) (flip zipWith3ExactNote (,,))
+
 
 ---------------------------------------------------------------------
 -- UTILITIES


### PR DESCRIPTION
Here are `zip3*` and `zipWith3*` functions, and test cases for them.

They are for the issue #14, and already verified by `cabal test` command (nevertheless I'm afraid the CI will fail due to the outdated copyright `2016` in `safe.cabal`.)