### PR TITLE
Remove >= in cabal-version

### DIFF
--- a/safe.cabal
+++ b/safe.cabal
@@ -1,4 +1,4 @@
-cabal-version:  >= 1.18
+cabal-version:  1.18
 build-type:     Simple
 name:           safe
 version:        0.3.19


### PR DESCRIPTION
Hopefully this suppresses the following warning:

```
Warning: safe.cabal:1:24: Packages with 'cabal-version: 1.12' or later should
specify a specific version of the Cabal spec of the form 'cabal-version: x.y'.
Use 'cabal-version: 1.18'.
```

Thanks for the pull request!

By raising this pull request you confirm you are licensing your contribution under all licenses that apply to this project (see LICENSE) and that you have no patents covering your contribution.

If you care, my PR preferences are at https://github.com/ndmitchell/neil#contributions, but they're all guidelines, and I'm not too fussy - you don't have to read them.
